### PR TITLE
Fix very short posts display scaped html

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -103,7 +103,7 @@
             {% elseif truncate and page.summary != page.content %}
             {{ page.summary|raw }}
             {% elseif truncate %}
-            {{ page.content|truncate(550) }}
+            {{ page.content|truncate(550)|raw }}
             {% else %}
             {{ page.content|raw }}
             {% set show_prev_next = true %}


### PR DESCRIPTION
html is scaped instead of used as is when a post is very short, but works well if it's long enough to get truncated