### PR TITLE
Fix link to share on twitter

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -119,7 +119,7 @@
                     </a>
                   </li>
                   <li>
-                    <a href="http://twitter.com/home?status={{ page.title|replace({' ': "%20"}) }}-{{ page.url(true) }}" target="_blank">
+                    <a href="http://twitter.com/share?text={{ page.title|replace({' ': "%20"}) }}&url={{ page.url(true) }}" target="_blank">
                       <i class="fa fa-twitter"></i>
                     </a>
                   </li>


### PR DESCRIPTION
The link to share a blog post to Twitter did not work. Link has been updated to the correct one.